### PR TITLE
Relax naming constraint for detecting nested serializers

### DIFF
--- a/graph_wrap/django_rest_framework/api_transformer.py
+++ b/graph_wrap/django_rest_framework/api_transformer.py
@@ -86,7 +86,7 @@ class SerializerTransformer(object):
         else:
             named_field = self._serializer
         serializer_cls_name = self._serializer.__class__.__name__
-        if serializer_cls_name == 'NestedSerializer':
+        if 'Nested' in serializer_cls_name:
             model = named_field.parent.Meta.model.__name__.lower()
             return '{}__{}_type'.format(model, named_field.field_name)
         else:
@@ -196,7 +196,7 @@ class RelatedValuedFieldTransformer(FieldTransformer):
             serializer_cls_name = self._field.child.__class__.__name__
         else:
             serializer_cls_name = self._field.__class__.__name__
-        if serializer_cls_name == 'NestedSerializer':
+        if 'Nested' in serializer_cls_name:
             model = self._field.parent.Meta.model.__name__.lower()
             return '{}__{}_type'.format(model, self._field.field_name)
         else:


### PR DESCRIPTION
Currently we seem to be checking the serializer name to determine whether it's a "nested" serializer: specifically, we're matching on the string "NestedSerializer."

Can we instead check for the string "Nested" anywhere in the serializer name to allow more flexibility in serializer naming? (There's likely a more canonical way to detect nested serializers, though nothing comes to me at the moment.)